### PR TITLE
Add Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Do you have a data file rather than a URL you would like to submit?
+Please upload your data to [Zenodo](https://zenodo.org) and link your data to this README via a URL.
+
+# Do your changes to the README roughly follow the following format?
+```
+Name of source: 
+Short description: 
+URL link to source:  
+```


### PR DESCRIPTION
So Github contributors link their raw data files via Zenodo rather than on Github